### PR TITLE
add base templates for issues and pull requests fixes (#3)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+### Prerequisites
+
+* [ ] Can you regularly reproduce the problem?
+* [ ] Are you running the latest version?
+
+For more information, see the `CONTRIBUTING` guide.
+
+### Description
+
+[Description of the bug or feature]
+
+### Versions
+
+You can get this information from executing `npm version`.
+
+Please include the version of browser that you are running.
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+#### Expected behavior:
+
+- [What you expected to happen]
+
+#### Actual behavior:
+
+- [What actually happened]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Verions**:
+* Node Version:
+* NPM Version:
+* Browser Version:
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, where appropriate
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
Fixes #3 

Creating templates for issues and PRs.

Creating these inside `./github` directory which GitHub handles out of the box: https://blog.github.com/2016-02-17-issue-and-pull-request-templates/